### PR TITLE
Fix uncaught error when 'Reprompt Master Password' option is enabled

### DIFF
--- a/export2.js
+++ b/export2.js
@@ -64,7 +64,7 @@ function exportToCsv(filename, rows) {
             navigator.msSaveBlob(blob, filename);
         } else {
             var link = document.createElement("a");
-            if (link.download !== "undefined") { // feature detection
+            if (link.download !== undefined) { // feature detection
                 // Browsers that support HTML5 download attribute
                 var url = URL.createObjectURL(blob);
                 link.setAttribute("href", url);

--- a/export2.js
+++ b/export2.js
@@ -14,7 +14,7 @@ start = setInterval(function(){
 function processItem(i){
   items[i].click();									// click edit button
   inter = setInterval(function(){					
-    if(typeof(username_fill)==undefined) return;	// wait until item loads
+    if(typeof(username_fill)=="undefined") return;	// wait until item loads
     clearInterval(inter);
     console.log( i + "\t"+addSpaces(30,title_fill.value) + addSpaces(30,username_fill.value) + password_fill.value);			// print item to see progress
     result.push( [  url_fill.value, title_fill.value, username_fill.value, "" , password_fill.value,"" , memo_fill.value ]);	// add values to results array to be converted into csv file. Empty values should be empty strings, don't use null or leave blank
@@ -64,7 +64,7 @@ function exportToCsv(filename, rows) {
             navigator.msSaveBlob(blob, filename);
         } else {
             var link = document.createElement("a");
-            if (link.download !== undefined) { // feature detection
+            if (link.download !== "undefined") { // feature detection
                 // Browsers that support HTML5 download attribute
                 var url = URL.createObjectURL(blob);
                 link.setAttribute("href", url);


### PR DESCRIPTION
When Reprompt Master Password' option is enabled for a password the script fails on line 19. (Chromium 50.0.2661.102, Linux).

`typeof` always returns a string. `typeof(username_fill) == undefined` returns false, so the script didn't wait for the item to be loaded. Fixed by comparing with string value.
